### PR TITLE
reduce delay :  30 seconds probably okay

### DIFF
--- a/bin/initmongo.sh
+++ b/bin/initmongo.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
-echo "initializing replset if necessary... in 60 seconds"
-sleep 60
+echo "initializing replset if necessary... in 30 seconds"
+sleep 30
 
-echo "after 60 seconds, checking for replset..."
+echo "after 30 seconds, checking for replset..."
 mongo $SNAP/bin/initmongoreplset.js
 


### PR DESCRIPTION
even for the slowest raspberry pi on SD card ...
60 seconds is too long to wait for fast 64 bit intel guys who used to have mongo up-and-running in 5 or 10 seconds